### PR TITLE
Generate SSP photometry

### DIFF
--- a/src/pst/SSP.py
+++ b/src/pst/SSP.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 import numpy as np
 
 from astropy.io import fits
@@ -291,7 +292,34 @@ class SSPBase(object):
             for j in range(self.ages.size):
                 mass_to_lum[i, j] = 1/np.mean(self.L_lambda[i, j][pts])
         return mass_to_lum
+    
+    def compute_photometry(self, filter_list, z_obs=0.0):
+        """Compute the SSP synthetic photometry of a set of filters.
+        
+        Paramteres
+        ----------
+        filter_list: list of pst.observable.Filter
+            A list of photometric filters.
 
+        Returns
+        -------
+        photometry: np.ndarray
+            Array storing the photometry. The dimensions correspond to
+            filter, metallicity and age.
+        """
+        print("Computing synthetic photometry for SSP model")
+        self.photometry = np.zeros((len(filter_list),
+                                    *self.L_lambda.shape[:-1]))
+        self.photometry_filters = filter_list
+        for ith, f in enumerate(filter_list):
+            f.interpolate(self.wavelength * (1 + z_obs))
+            self.photometry[ith], _ = f.get_fnu(
+                    self.L_lambda  * u.Msun / 4 / np.pi / (10 * u.pc)**2,
+                    mask_nan=False)
+
+    def copy(self):
+        """Return a copy of the SSP model."""
+        return deepcopy(self)
 
 class PopStar(SSPBase):
     """PopStar SSP models (Mollá+09)."""

--- a/src/pst/observables.py
+++ b/src/pst/observables.py
@@ -156,13 +156,15 @@ class Filter(object):
         spectra_err = self.check_spectra(spectra_err)
         if mask_nan:
             mask = np.isfinite(spectra)
-        else:
-            mask = np.ones_like(spectra, dtype=bool)
-
-        photon_flux = np.trapz(
-            spectra[mask] / (constants.h * constants.c / self.wavelength[mask]
+            photon_flux = np.trapz(
+                spectra[mask] / (constants.h * constants.c / self.wavelength[mask]
                                    ) * self.response[mask],
-            x=self.wavelength[mask])
+                x=self.wavelength[mask])
+        else:
+            photon_flux = np.trapz(
+                spectra / (constants.h * constants.c / self.wavelength
+                                   ) * self.response,
+                x=self.wavelength)
 
         if spectra_err is not None:
             if mask_nan:
@@ -178,10 +180,11 @@ class Filter(object):
             photon_flux_err = None
         return photon_flux, photon_flux_err
     
-    def get_ab(self, spectra, spectra_err=None):
-        n_photons, n_photons_err = self.get_photons(spectra, spectra_err)
+    def get_ab(self, spectra, spectra_err=None, mask_nan=True):
+        n_photons, n_photons_err = self.get_photons(spectra, spectra_err, mask_nan=mask_nan)
         norm_photons, _ = self.get_photons(
-            3630.781 * u.Jy * np.ones(spectra.size) * constants.c / self.wavelength**2)
+            3630.781 * u.Jy * np.ones(spectra.shape) * constants.c / self.wavelength**2,
+            mask_nan=False)
         m_ab = - 2.5 * np.log10(n_photons / norm_photons)
         if n_photons_err is None:
             m_ab_err = None
@@ -189,12 +192,12 @@ class Filter(object):
             m_ab_err = 2.5 / np.log(10) * n_photons_err / n_photons
         return m_ab, m_ab_err
 
-    def get_fnu(self, spectra, spectra_err):
+    def get_fnu(self, spectra, spectra_err=None, mask_nan=True):
         """Compute the  specific flux per frequency unit from a spectra."""
-        n_photons, n_photons_err = self.get_photons(spectra, spectra_err)
+        n_photons, n_photons_err = self.get_photons(spectra, spectra_err, mask_nan=mask_nan)
         norm_photons, _ = self.get_photons(
-            3630.781 * u.Jy * np.ones(spectra.size) * constants.c / self.wavelength**2)
-        print(n_photons.unit, norm_photons.unit)
+            3630.781 * u.Jy * np.ones(spectra.shape) * constants.c / self.wavelength**2,
+            mask_nan=False)
         f_nu = n_photons / norm_photons * 3630.781 * u.Jy
         f_nu = f_nu.to('Jy')
         if spectra_err is None:


### PR DESCRIPTION
I am starting to play with a way of generating photometry for the SSPs. For now I have implemented a simple method that takes as input a list of filters and generates the photometry (stored in the form of flux density). This is currently crucial for the next steps in terms of SED fitting using photometry (+spectra).

This to keep in mind:
- When including dust extinction, this should be done prior calling this method.
- We can think about ways to extinguish `L_lambda`.
- For now, every time I am changing extinction I create a new copy of the SSP (this is an additional `copy` method that I've included). For LR spectra this is more or less okey (~ms), but in the case of HR spectra it is quite slow.
- Probably you do want to use any of this methods because you create fixed grids outside SSP.

The most important aspects to think about are. Some wild thoughts while attending a talk:
- Our models only use `L_lambda` for computing the final SED. If, for example, we want to generate both spectra and photometric SEDs this needs to be revised.
- Alternatively, we could generate two versions of the SSPs, one with the spectra and another one with the photometry and the model is called twice.
- Alt-alternative, the model has an intermediate method that returns not the SED, but the weights that are used to generate both the spectra and the photometry.
