### PR TITLE
Missing redshift term in SSP photometry

### DIFF
--- a/src/pst/SSP.py
+++ b/src/pst/SSP.py
@@ -317,6 +317,7 @@ class SSPBase(object):
             flux, _ = f.get_fnu(
                     self.L_lambda  * u.Msun / 4 / np.pi / (10 * u.pc)**2,
                     mask_nan=False)
+            flux /= 1 + z_obs
             self.photometry[ith] = flux.to('Jy') / u.Msun
         return self.photometry
 


### PR DESCRIPTION
There was a missing factor `1 /  (1 + z)` in the computation of the SSP magnitudes.