### PR TITLE
Include dummy metallicity

### DIFF
--- a/src/pst/models.py
+++ b/src/pst/models.py
@@ -467,11 +467,11 @@ class TabularCEM(ChemicalEvolutionModel):
     """
     def __init__(self, times, masses, metallicities, **kwargs):
         super().__init__(**kwargs)
-        self.table_t = times
+        self.table_t = check_unit(times, u.Gyr)
         # Make sure that time is crescent
         sort_times = np.argsort(self.table_t)
         self.table_t = self.table_t[sort_times]
-        self.table_mass = masses[sort_times]
+        self.table_mass = check_unit(masses[sort_times], u.Msun)
         self.table_metallicity = metallicities[sort_times]
 
     @u.quantity_input
@@ -540,7 +540,10 @@ class TabularCEM_ZPowerLaw(MassPropMetallicityMixin, TabularCEM):
     def __init__(self, times, masses, alpha_powerlaw, ism_metallicity_today, **kwargs):
         self.ism_metallicity_today = ism_metallicity_today
         self.alpha_powerlaw = alpha_powerlaw
-        super().__init__(times, masses, **kwargs)
+        # Create a dummy metallicity that is passed to the TabularCEM constructor
+        # but never used
+        metallicity = np.zeros(times.size)
+        super().__init__(times, masses, metallicity, **kwargs)
 
 
 class ParticleListCEM(ChemicalEvolutionModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -68,12 +68,12 @@ class TestModels(unittest.TestCase):
         low_res_time = np.linspace(0, 13.7, 10) * u.Gyr
         masses = 1 - np.exp(-low_res_time / 3.0 / u.Gyr)
         model = models.TabularCEM(
-            times=low_res_time, masses=masses,
+            times=low_res_time, masses=masses * u.Msun,
             metallicities=np.full(masses.size, fill_value=0.02))
 
         mass = model.stellar_mass_formed(self.dummy_times)
         real_mass = 1 - np.exp(- self.dummy_times / 3 / u.Gyr)
-        self.assertTrue(np.allclose(mass, real_mass, rtol=1e-2))
+        self.assertTrue(np.allclose(mass, real_mass * u.Msun, rtol=1e-2))
 
     def test_particle_grid(self):
         n_particles = 10000


### PR DESCRIPTION
The Tabular model that uses a power law to model the metallicity evolution needs to pass a dummy `metallicity` to the constructor of TabularCEM. This quantity is never used since the method `ism_metallicity` is overridden by the mixin. The alternative is to convert that quantity into an optional argument in the TabularCEM constructor.